### PR TITLE
Add attention property to verbs and add attention view to study page

### DIFF
--- a/src/app/components/table/cells/cell.directive.ts
+++ b/src/app/components/table/cells/cell.directive.ts
@@ -22,7 +22,7 @@ export abstract class CellDirective<T> {
     }
   }
 
-  protected calculateValidity(value: T) : boolean {
+  protected calculateValidity(value: T): boolean {
     return value == this.data;
   }
 

--- a/src/app/components/table/cells/cell.directive.ts
+++ b/src/app/components/table/cells/cell.directive.ts
@@ -12,7 +12,7 @@ export abstract class CellDirective<T> {
   protected onChange(value: T) {
     this.setValue(value);
 
-    const newIsValid = value == this.data;;
+    const newIsValid = this.calculateValidity(value);
     this.setNewValidity(newIsValid);
   }
 
@@ -20,6 +20,10 @@ export abstract class CellDirective<T> {
     if (this.data != value) {
       this.valueChange.emit(value);
     }
+  }
+
+  protected calculateValidity(value: T) : boolean {
+    return value == this.data;
   }
 
   protected setNewValidity(valid: boolean) {

--- a/src/app/components/table/cells/checkbox-cell/checkbox-cell.component.html
+++ b/src/app/components/table/cells/checkbox-cell/checkbox-cell.component.html
@@ -1,4 +1,7 @@
-<label>
-  <input type="checkbox" [(ngModel)]="data" />
-  Check me
-</label>
+<div class="flex items-center justify-center">
+  <input
+    type="checkbox"
+    [(ngModel)]="input"
+    (ngModelChange)="onChange(input)"
+  />
+</div>

--- a/src/app/components/table/cells/checkbox-cell/checkbox-cell.component.ts
+++ b/src/app/components/table/cells/checkbox-cell/checkbox-cell.component.ts
@@ -8,7 +8,22 @@ import { CellDirective } from '../cell.directive';
   styleUrl: './checkbox-cell.component.css'
 })
 export class CheckboxCellComponent extends CellDirective<boolean> {
+  public input: boolean = false;
+
   CheckboxCellComponent() {
     this.isValid = this.data == false;
+  }
+
+  ngOnInit() {
+    this.input = this.data;
+  }
+
+  protected override onChange(value: boolean) {
+    this.setValue(value);
+    this.data = value;
+  }
+
+  protected override calculateValidity(input: boolean): boolean {
+    return true;
   }
 }

--- a/src/app/components/table/cells/text-input-cell/text-input-cell.component.ts
+++ b/src/app/components/table/cells/text-input-cell/text-input-cell.component.ts
@@ -17,7 +17,9 @@ export class TextInputCellComponent extends CellDirective<string> {
   
   onBlur() {
     this.isTouched = true;
-    this.setNewValidity(this.input == this.data);
+    
+    const newValidity = this.calculateValidity(this.input);
+    this.setNewValidity(newValidity);
   }
 
   protected override onChange(value: string) {

--- a/src/app/components/table/cells/text-input-cell/text-input-cell.component.ts
+++ b/src/app/components/table/cells/text-input-cell/text-input-cell.component.ts
@@ -17,7 +17,7 @@ export class TextInputCellComponent extends CellDirective<string> {
 
   onBlur() {
     this.isTouched = true;
-    
+
     const newValidity = this.calculateValidity(this.input);
     this.setNewValidity(newValidity);
   }

--- a/src/app/components/table/row/row.component.html
+++ b/src/app/components/table/row/row.component.html
@@ -18,7 +18,7 @@
       app-checkbox-cell
       *ngIf="col.type === 'checkbox'"
       [data]="col.data(row)"
-      (valueChange)="onValueChange($event, col.key)"
+      (valueChange)="col.onChange(row, $event)"
       (validityChange)="onValidityChange($event, col.key)"
     ></div>
 

--- a/src/app/components/table/table/table.component.ts
+++ b/src/app/components/table/table/table.component.ts
@@ -33,6 +33,7 @@ export interface DropdownColumnProps<T> extends BaseColumnProps<T> {
 export interface CheckboxColumnProps<T> extends BaseColumnProps<T> {
   type: 'checkbox';
   data: (row: T) => boolean;
+  onChange: (row: T, value: boolean) => void;
 }
 
 

--- a/src/app/pages/study/study.component.html
+++ b/src/app/pages/study/study.component.html
@@ -1,3 +1,6 @@
 <div class="p-4">
+  <button class="btn" (click)="toggleFocusMode()">
+    Focus mode: {{ focusMode }}
+  </button>
   <app-table [data]="verbs" [columns]="verbColumns"></app-table>
 </div>

--- a/src/app/pages/study/study.component.ts
+++ b/src/app/pages/study/study.component.ts
@@ -34,15 +34,15 @@ export class StudyComponent implements OnInit {
       data: (verb: Verb) => `${verb.auxiliaryVerb} ${verb.perfekt}`,
     },
     {
-      type: "checkbox",
-      key: "attention",
-      header: "Attention",
+      type: 'checkbox',
+      key: 'attention',
+      header: 'Attention',
       data: (verb: Verb) => verb.attention,
-      onChange: (verb : Verb, value: boolean) => {
+      onChange: (verb: Verb, value: boolean) => {
         this.verbService.setAttention(verb.infinitiv, value);
         this.renewAttention();
-      }
-    }
+      },
+    },
   ];
 
   constructor(private verbService: VerbService) {}
@@ -50,7 +50,9 @@ export class StudyComponent implements OnInit {
   ngOnInit() {
     this.verbService.getVerbs().subscribe((data) => {
       this.allVerbs = data;
-      this.verbs = this.focusMode ? this.allVerbs.filter(verb => verb.attention) : this.allVerbs;
+      this.verbs = this.focusMode
+        ? this.allVerbs.filter((verb) => verb.attention)
+        : this.allVerbs;
     });
   }
 
@@ -61,7 +63,11 @@ export class StudyComponent implements OnInit {
 
   private renewAttention() {
     const attentionVerbs = this.verbService.getAttentionVerbs();
-    this.allVerbs.forEach(verb => verb.attention = attentionVerbs.has(verb.infinitiv));
-    this.verbs = this.focusMode ? this.allVerbs.filter(verb => verb.attention) : this.allVerbs; 
+    this.allVerbs.forEach(
+      (verb) => (verb.attention = attentionVerbs.has(verb.infinitiv)),
+    );
+    this.verbs = this.focusMode
+      ? this.allVerbs.filter((verb) => verb.attention)
+      : this.allVerbs;
   }
 }

--- a/src/app/pages/study/study.component.ts
+++ b/src/app/pages/study/study.component.ts
@@ -11,7 +11,10 @@ import { TableModule } from '../../components/table/table.module';
   templateUrl: './study.component.html',
 })
 export class StudyComponent implements OnInit {
-  verbs: Verb[] = [];
+  private allVerbs: Verb[] = [];
+
+  public verbs: Verb[] = [];
+  public focusMode: boolean = false;
 
   public verbColumns: ColumnProps<Verb>[] = [
     {
@@ -32,13 +35,35 @@ export class StudyComponent implements OnInit {
       header: 'Perfekt',
       data: (verb: Verb) => `${verb.auxiliaryVerb} ${verb.perfekt}`,
     },
+    {
+      type: "checkbox",
+      key: "attention",
+      header: "Attention",
+      data: (verb: Verb) => verb.attention,
+      onChange: (verb : Verb, value: boolean) => {
+        this.verbService.setAttention(verb.infinitiv, value);
+        this.renewAttention();
+      }
+    }
   ];
 
   constructor(private verbService: VerbService) {}
 
   ngOnInit() {
     this.verbService.getVerbs().subscribe((data) => {
-      this.verbs = data;
+      this.allVerbs = data;
+      this.verbs = this.focusMode ? this.allVerbs.filter(verb => verb.attention) : this.allVerbs;
     });
+  }
+
+  public toggleFocusMode() {
+    this.focusMode = !this.focusMode;
+    this.renewAttention();
+  }
+
+  private renewAttention() {
+    const attentionVerbs = this.verbService.getAttentionVerbs();
+    this.allVerbs.forEach(verb => verb.attention = attentionVerbs.has(verb.infinitiv));
+    this.verbs = this.focusMode ? this.allVerbs.filter(verb => verb.attention) : this.allVerbs; 
   }
 }

--- a/src/app/services/verb.service.ts
+++ b/src/app/services/verb.service.ts
@@ -11,6 +11,7 @@ export interface Verb {
   auxiliaryVerb: string;
   perfekt: string;
   level: string;
+  attention: boolean;
 }
 
 @Injectable({
@@ -18,22 +19,46 @@ export interface Verb {
 })
 export class VerbService {
   private csvUrl = 'assets/verbs.csv';
+  private attentionLocalStorageKey = 'attentionVerbs';
+
   private verbsCache$: Observable<Verb[]> | null = null;
 
   constructor(private http: HttpClient) {}
 
-  getVerbs(): Observable<Verb[]> {
+  public getVerbs(): Observable<Verb[]> {
+    const attentionVerbs = this.getAttentionVerbs();
+
     if (!this.verbsCache$) {
       this.verbsCache$ = this.http
         .get(this.csvUrl, { responseType: 'text' })
         .pipe(
           map((csvData) => {
             const parsed = Papa.parse(csvData, { header: true });
-            return parsed.data as Verb[];
+            const verbs = parsed.data as Verb[];
+            verbs.map(verb => verb.attention = attentionVerbs.has(verb.infinitiv));
+
+            return verbs;
           }),
           shareReplay(1), // Cache the result for future calls
         );
     }
+
     return this.verbsCache$;
+  }
+
+  public setAttention(infinitiv: string, attention: boolean): void {
+    const attentionVerbsRaw = localStorage.getItem(this.attentionLocalStorageKey);
+    const attentionVerbs = new Set(attentionVerbsRaw?.split(';'));
+    if (attention) {
+      attentionVerbs.add(infinitiv);
+    } else {
+      attentionVerbs.delete(infinitiv);
+    }
+    localStorage.setItem(this.attentionLocalStorageKey, Array.from(attentionVerbs.values()).join(';'));
+  }
+
+  public getAttentionVerbs(): Set<string>{
+    const attentionVerbsRaw = localStorage.getItem(this.attentionLocalStorageKey) || '';
+    return new Set(attentionVerbsRaw.split(';'));
   }
 }

--- a/src/app/services/verb.service.ts
+++ b/src/app/services/verb.service.ts
@@ -35,7 +35,9 @@ export class VerbService {
           map((csvData) => {
             const parsed = Papa.parse(csvData, { header: true });
             const verbs = parsed.data as Verb[];
-            verbs.map(verb => verb.attention = attentionVerbs.has(verb.infinitiv));
+            verbs.map(
+              (verb) => (verb.attention = attentionVerbs.has(verb.infinitiv)),
+            );
 
             return verbs;
           }),
@@ -47,18 +49,24 @@ export class VerbService {
   }
 
   public setAttention(infinitiv: string, attention: boolean): void {
-    const attentionVerbsRaw = localStorage.getItem(this.attentionLocalStorageKey);
+    const attentionVerbsRaw = localStorage.getItem(
+      this.attentionLocalStorageKey,
+    );
     const attentionVerbs = new Set(attentionVerbsRaw?.split(';'));
     if (attention) {
       attentionVerbs.add(infinitiv);
     } else {
       attentionVerbs.delete(infinitiv);
     }
-    localStorage.setItem(this.attentionLocalStorageKey, Array.from(attentionVerbs.values()).join(';'));
+    localStorage.setItem(
+      this.attentionLocalStorageKey,
+      Array.from(attentionVerbs.values()).join(';'),
+    );
   }
 
-  public getAttentionVerbs(): Set<string>{
-    const attentionVerbsRaw = localStorage.getItem(this.attentionLocalStorageKey) || '';
+  public getAttentionVerbs(): Set<string> {
+    const attentionVerbsRaw =
+      localStorage.getItem(this.attentionLocalStorageKey) || '';
     return new Set(attentionVerbsRaw.split(';'));
   }
 }


### PR DESCRIPTION
This PR solves issue #1.

It adds:
- Attention property to verbs, which is stored in the local storage of the browser.
- A toggled view in the study page, which shows only the verbs which have been marked with attention.
- Instant update of the study page based on attention.